### PR TITLE
Fixes for signal handlers

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -12,6 +12,7 @@ files are as follows.
 src/x86_decode.c
 src/x86_emulate.h
 src/x86_defs.h
+libsystrap/restorer.c
 
 Note also that building this software involves downloading and compiling
 source code from other projects (collected under the contrib/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ standalone (does not rely on external libraries) and must run before any
 other code. It replaces system calls in the original code with traps and
 installs handling mechanisms.
 
-`instr.c' actually does the instrumentation, using opdis to disassemble.
+`instr.c' actually does the instrumentation.
 
 `do-syscall.c` is the interface between the previously mentioned trapping
 mechanism and the user-provided handling tools.
@@ -80,5 +80,6 @@ mechanism and the user-provided handling tools.
 sytem calls required in the library itself, since it cannot rely on the C
 library.
 
-`restorer.s` is a small assembly snippet required by the signal handler.
+`restorer.c` is a copy of glibc's signal restorer needed to return into user
+code.
 

--- a/libsystrap/raw-syscalls.h
+++ b/libsystrap/raw-syscalls.h
@@ -142,7 +142,7 @@ struct ibcs_sigframe
 	struct __asm_siginfo info;
 };
 
-void restore_rt(void); /* in restorer.s */
+extern void restore_rt(void) __asm__("__restore_rt"); /* in restorer.c */
 
 void raw_exit(int status) __attribute__((noreturn));
 int raw_open(const char *pathname, int flags) __attribute__((noinline));

--- a/libsystrap/raw-syscalls.h
+++ b/libsystrap/raw-syscalls.h
@@ -43,6 +43,7 @@
 #define sigval __asm_sigval
 #define sigval_t __asm_sigval_t
 #define siginfo __asm_siginfo
+#define stack_t __asm_stack_t
 #define ucontext __asm_ucontext
 #define pid_t __kernel_pid_t
 /* sys/time.h (which later code wants to include)
@@ -73,6 +74,7 @@
 #undef sigval
 #undef sigval_t
 #undef siginfo
+#undef stack_t
 #undef pid_t
 
 #elif defined(__FreeBSD__)

--- a/libsystrap/restorer.c
+++ b/libsystrap/restorer.c
@@ -1,0 +1,148 @@
+/* Simplified version of sysdeps/unix/sysv/linux/x86_64/sigaction.c to only
+ * keep the restorer definition.
+
+ * Original copyright notice:
+   POSIX.1 `sigaction' call for Linux/x86-64.
+   Copyright (C) 2001-2018 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#define CFI_STRINGIFY(Name) CFI_STRINGIFY2 (Name)
+#define CFI_STRINGIFY2(Name) #Name
+
+#define LP_SIZE "8"
+
+#define __NR_rt_sigreturn 15
+
+/* NOTE: Please think twice before making any changes to the bits of
+   code below.  GDB needs some intimate knowledge about it to
+   recognize them as signal trampolines, and make backtraces through
+   signal handlers work right.  Important are both the names
+   (__restore_rt) and the exact instruction sequence.
+   If you ever feel the need to make any changes, please notify the
+   appropriate GDB maintainer.
+
+   The unwind information starts a byte before __restore_rt, so that
+   it is found when unwinding, to get an address the unwinder assumes
+   will be in the middle of a call instruction.  See the Linux kernel
+   (the i386 vsyscall, in particular) for an explanation of the complex
+   unwind information used here in order to get the traditional CFA.
+   We do not restore cs - it's only stored as two bytes here so that's
+   a bit tricky.  We don't use the gas cfi directives, so that we can
+   reliably add .cfi_signal_frame.  */
+
+// From "ucontext_i.h"
+#define oRBP 120
+#define oRSP 160
+#define oRBX 128
+#define oR8 40
+#define oR9 48
+#define oR10 56
+#define oR11 64
+#define oR12 72
+#define oR13 80
+#define oR14 88
+#define oR15 96
+#define oRDI 104
+#define oRSI 112
+#define oRDX 136
+#define oRAX 144
+#define oRCX 152
+#define oRIP 168
+#define oEFL 176
+
+#define do_cfa_expr						\
+  "	.byte 0x0f\n"		/* DW_CFA_def_cfa_expression */	\
+  "	.uleb128 2f-1f\n"	/* length */			\
+  "1:	.byte 0x77\n"		/* DW_OP_breg7 */		\
+  "	.sleb128 " CFI_STRINGIFY (oRSP) "\n"			\
+  "	.byte 0x06\n"		/* DW_OP_deref */		\
+  "2:"
+
+#define do_expr(regno, offset)					\
+  "	.byte 0x10\n"		/* DW_CFA_expression */		\
+  "	.uleb128 " CFI_STRINGIFY (regno) "\n"			\
+  "	.uleb128 2f-1f\n"	/* length */			\
+  "1:	.byte 0x77\n"		/* DW_OP_breg7 */		\
+  "	.sleb128 " CFI_STRINGIFY (offset) "\n"			\
+  "2:"
+
+#define RESTORE(name, syscall) RESTORE2 (name, syscall)
+# define RESTORE2(name, syscall) \
+__asm__									\
+  (									\
+   /* `nop' for debuggers assuming `call' should not disalign the code.  */ \
+   "	nop\n"								\
+   ".align 16\n"							\
+   ".LSTART_" #name ":\n"						\
+   "	.type __" #name ",@function\n"					\
+   "    .globl __" #name "\n" \
+   "__" #name ":\n"							\
+   "	movq $" #syscall ", %rax\n"					\
+   "	syscall\n"							\
+   ".LEND_" #name ":\n"							\
+   ".section .eh_frame,\"a\",@progbits\n"				\
+   ".LSTARTFRAME_" #name ":\n"						\
+   "	.long .LENDCIE_" #name "-.LSTARTCIE_" #name "\n"		\
+   ".LSTARTCIE_" #name ":\n"						\
+   "	.long 0\n"	/* CIE ID */					\
+   "	.byte 1\n"	/* Version number */				\
+   "	.string \"zRS\"\n" /* NUL-terminated augmentation string */	\
+   "	.uleb128 1\n"	/* Code alignment factor */			\
+   "	.sleb128 -8\n"	/* Data alignment factor */			\
+   "	.uleb128 16\n"	/* Return address register column (rip) */	\
+   /* Augmentation value length */					\
+   "	.uleb128 .LENDAUGMNT_" #name "-.LSTARTAUGMNT_" #name "\n"	\
+   ".LSTARTAUGMNT_" #name ":\n"						\
+   "	.byte 0x1b\n"	/* DW_EH_PE_pcrel|DW_EH_PE_sdata4. */		\
+   ".LENDAUGMNT_" #name ":\n"						\
+   "	.align " LP_SIZE "\n"						\
+   ".LENDCIE_" #name ":\n"						\
+   "	.long .LENDFDE_" #name "-.LSTARTFDE_" #name "\n" /* FDE len */	\
+   ".LSTARTFDE_" #name ":\n"						\
+   "	.long .LSTARTFDE_" #name "-.LSTARTFRAME_" #name "\n" /* CIE */	\
+   /* `LSTART_' is subtracted 1 as debuggers assume a `call' here.  */	\
+   "	.long (.LSTART_" #name "-1)-.\n" /* PC-relative start addr.  */	\
+   "	.long .LEND_" #name "-(.LSTART_" #name "-1)\n"			\
+   "	.uleb128 0\n"			/* FDE augmentation length */	\
+   do_cfa_expr								\
+   do_expr (8 /* r8 */, oR8)						\
+   do_expr (9 /* r9 */, oR9)						\
+   do_expr (10 /* r10 */, oR10)						\
+   do_expr (11 /* r11 */, oR11)						\
+   do_expr (12 /* r12 */, oR12)						\
+   do_expr (13 /* r13 */, oR13)						\
+   do_expr (14 /* r14 */, oR14)						\
+   do_expr (15 /* r15 */, oR15)						\
+   do_expr (5 /* rdi */, oRDI)						\
+   do_expr (4 /* rsi */, oRSI)						\
+   do_expr (6 /* rbp */, oRBP)						\
+   do_expr (3 /* rbx */, oRBX)						\
+   do_expr (1 /* rdx */, oRDX)						\
+   do_expr (0 /* rax */, oRAX)						\
+   do_expr (2 /* rcx */, oRCX)						\
+   do_expr (7 /* rsp */, oRSP)						\
+   do_expr (16 /* rip */, oRIP)						\
+   /* libgcc-4.1.1 has only `DWARF_FRAME_REGISTERS == 17'.  */		\
+   /* do_expr (49 |* rflags *|, oEFL) */				\
+   /* `cs'/`ds'/`fs' are unaligned and a different size.  */		\
+   /* gas: Error: register save offset not a multiple of 8  */		\
+   "	.align " LP_SIZE "\n"						\
+   ".LENDFDE_" #name ":\n"						\
+   "	.previous\n"							\
+   );
+/* The return code for realtime-signals.  */
+RESTORE (restore_rt, __NR_rt_sigreturn)

--- a/libsystrap/restorer.s
+++ b/libsystrap/restorer.s
@@ -1,6 +1,0 @@
-	.section	.text
-	.globl restore_rt
-restore_rt:
-	movq $0xf, %rax
-	syscall
-	nopl   0x0(%rax)

--- a/libsystrap/trap.c
+++ b/libsystrap/trap.c
@@ -112,7 +112,10 @@ void walk_instructions(unsigned char *pos, unsigned char *end,
 	}
 }
 
-static unsigned char X86_64_MOV_0xF_RAX[] = {0x48, 0xc7, 0xc0, 0x0f, 0, 0, 0};
+static const unsigned char X86_64_MOV_0x38_EAX[] = {0xb8, 0x38, 0, 0, 0};
+static const unsigned char X86_64_MOV_0xF_RAX[] = {0x48, 0xc7, 0xc0, 0x0f, 0, 0, 0};
+static const unsigned char *blacklisted_prev_instrs[] = {X86_64_MOV_0x38_EAX, X86_64_MOV_0xF_RAX, NULL};
+static const unsigned int blacklisted_prev_lengths[] = {5, 7};
 static void instruction_cb(unsigned char *pos, unsigned len, void *arg)
 {
 	if (is_syscall_instr(pos, pos + len))
@@ -124,14 +127,24 @@ static void instruction_cb(unsigned char *pos, unsigned len, void *arg)
 		 * This hack is a bit unsafe and not portable at all !!!
 		 * A better way to do this would be to do a simple analysis of constant
 		 * values for each function and to only instrument syscalls if needed */
-		for (int i = 1; i <= 7; i++)
+		/* Seems like we need to do the same for syscall 56 (clone)...
+		 * We REALLY want a way to accurately remove harmful instrumentations. */
+		const unsigned char **blinstr = blacklisted_prev_instrs;
+		const unsigned int *bllen = blacklisted_prev_lengths;
+		for (; *blinstr; ++blinstr, ++bllen)
 		{
-			if (pos[-i] != X86_64_MOV_0xF_RAX[7-i])
+			int match = 1;
+			for (int i = 1; i <= *bllen; i++)
 			{
-				replace_syscall_with_ud2(pos, len);
-				break;
+				if (pos[-i] != (*blinstr)[*bllen-i])
+				{
+					match = 0;
+					break;
+				}
 			}
+			if (match) return;
 		}
+		replace_syscall_with_ud2(pos, len);
 	}
 }
 


### PR DESCRIPTION
This push request contains two fixes for signal handlers management in libsystrap:
- The first one is a workaround to never instrument the sigreturn syscall, because doing so would create another signal frame and return from this new one.
- The second fixes GDB backtraces when a trapped syscall is involved