### PR TITLE
fix: initialize syscall structs properly

### DIFF
--- a/src/do-syscall.h
+++ b/src/do-syscall.h
@@ -60,11 +60,11 @@ __systrap_post_handling(struct generic_syscall *gsp, long int ret, _Bool do_call
  * struct fields are ignored by the corresponding do_syscallN calls,
  * so that wouldn't happen anyway. Oh well... it's briefer too. */
 #define MKGS0(op)                         { NULL, op }
-#define MKGS1(op, a1)                     { NULL, op, { (long) a1 } }
-#define MKGS2(op, a1, a2)                 { NULL, op, { (long) a1, (long) a2 } }
-#define MKGS3(op, a1, a2, a3)             { NULL, op, { (long) a1, (long) a2, (long) a3 } }
-#define MKGS4(op, a1, a2, a3, a4)         { NULL, op, { (long) a1, (long) a2, (long) a3, (long) a4 } }
-#define MKGS5(op, a1, a2, a3, a4, a5)     { NULL, op, { (long) a1, (long) a2, (long) a3, (long) a4, (long) a5 } }
+#define MKGS1(op, a1)                     { NULL, op, { (long) a1, NULL, NULL, NULL, NULL, NULL } }
+#define MKGS2(op, a1, a2)                 { NULL, op, { (long) a1, (long) a2, NULL, NULL, NULL, NULL } }
+#define MKGS3(op, a1, a2, a3)             { NULL, op, { (long) a1, (long) a2, (long) a3, NULL, NULL, NULL } }
+#define MKGS4(op, a1, a2, a3, a4)         { NULL, op, { (long) a1, (long) a2, (long) a3, (long) a4, NULL, NULL } }
+#define MKGS5(op, a1, a2, a3, a4, a5)     { NULL, op, { (long) a1, (long) a2, (long) a3, (long) a4, (long) a5, NULL } }
 #define MKGS6(op, a1, a2, a3, a4, a5, a6) { NULL, op, { (long) a1, (long) a2, (long) a3, (long) a4, (long) a5, (long) a6 } }
 
 extern inline long int 


### PR DESCRIPTION
Fixes a SEGFAULT occurring when instantiating parameter structs to `do_syscalln` functions, compiled under gcc 13.2.0

```

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7af5868 in raw_open (pathname=0x7ffff7d6a89e "/proc/self/maps", 
    flags=0, mode=0) at raw-syscalls.c:21
21              struct generic_syscall gs = { NULL, SYS_open, { pathname, flags, mode } };
(gdb) bt
#0  0x00007ffff7af5868 in raw_open (pathname=0x7ffff7d6a89e "/proc/self/maps", flags=0, mode=0) at raw-syscalls.c:21
#1  0x00007ffff7af4cb5 in trap_all_mappings () at trace-syscalls.c:81
#2  0x00007ffff7af22a6 in __wrap_enter (entry_point=0x555555575540) at pre-entry.c:42
#3  0x00007ffff7af1d06 in main (argc=2, argv=0x7fffffffd788)
```

Dump of raw_open

```asm
0x00007ffff7af5850 <+0>:     endbr64                  # Preamble
0x00007ffff7af5854 <+4>:     push   %rbp              
0x00007ffff7af5855 <+5>:     mov    %rsp,%rbp       
0x00007ffff7af5858 <+8>:     push   %r12             
0x00007ffff7af585a <+10>:    mov    %rdi,-0x68(%rbp)  
0x00007ffff7af585e <+14>:    mov    %esi,-0x6c(%rbp)  
0x00007ffff7af5861 <+17>:    mov    %edx,-0x70(%rbp)  
0x00007ffff7af5864 <+20>:    pxor   %xmm0,%xmm0       
0x00007ffff7af5868 <+24>:    movaps %xmm0,-0x60(%rbp) # struct init - 64 bytes < SEGFAULT, not aligned
0x00007ffff7af586c <+28>:    movaps %xmm0,-0x50(%rbp) 
0x00007ffff7af5870 <+32>:    movaps %xmm0,-0x40(%rbp) 
0x00007ffff7af5874 <+36>:    movaps %xmm0,-0x30(%rbp) 
0x00007ffff7af5878 <+40>:    movl   $0x2,-0x58(%rbp)  # Set syscall number (SYS_open) in struct
0x00007ffff7af587f <+47>:    mov    -0x68(%rbp),%rax  
0x00007ffff7af5883 <+51>:    mov    %rax,-0x50(%rbp)  # Store pathname in struct
0x00007ffff7af5887 <+55>:    mov    -0x6c(%rbp),%eax 
0x00007ffff7af588a <+58>:    cltq 
0x00007ffff7af588c <+60>:    mov    %rax,-0x48(%rbp)  # Store flags in struct
0x00007ffff7af5890 <+64>:    mov    -0x70(%rbp),%eax  
0x00007ffff7af5893 <+67>:    cltq                     
0x00007ffff7af5895 <+69>:    mov    %rax,-0x40(%rbp)  # Store mode in struct
0x00007ffff7af5899 <+73>:    lea    -0x60(%rbp),%rax  
0x00007ffff7af589d <+77>:    mov    %rax,-0x18(%rbp)  # Store address of struct in local variable
0x00007ffff7af58a1 <+81>:    mov    -0x18(%rbp),%rax  
0x00007ffff7af58a5 <+85>:    mov    0x8(%rax),%eax    # Load syscall number from struct into eax
0x00007ffff7af58a8 <+88>:    cltq                    
0x00007ffff7af58aa <+90>:    mov    %rax,-0x20(%rbp)  
0x00007ffff7af58ae <+94>:    mov    -0x18(%rbp),%rax  
0x00007ffff7af58b2 <+98>:    mov    0x10(%rax),%r8    # struct.arg[1] ("pathname") -> r8
0x00007ffff7af58b6 <+102>:   mov    -0x18(%rbp),%rax  
0x00007ffff7af58ba <+106>:   mov    0x18(%rax),%r9    # struct.arg[1] ("flags") -> r9
0x00007ffff7af58be <+110>:   mov    -0x18(%rbp),%rax  
0x00007ffff7af58c2 <+114>:   mov    0x20(%rax),%r10   # struct.arg[2] ("mode") -> r10
0x00007ffff7af58c6 <+118>:   mov    -0x20(%rbp),%rax  # syscall number
0x00007ffff7af58ca <+122>:   mov    %r8,%rdi          # arg[0]
0x00007ffff7af58cd <+125>:   mov    %r9,%rsi          # arg[1]
0x00007ffff7af58d0 <+128>:   mov    %r10,%rdx         # arg[2]
0x00007ffff7af58d3 <+131>:   mov    %rsp,%r12       # save rsp
0x00007ffff7af58d6 <+134>:   and    $0xf,%r12         # Align stack pointer 
0x00007ffff7af58da <+138>:   sub    %r12,%rsp         
0x00007ffff7af58dd <+141>:   syscall 
0x00007ffff7af58df <+143>:   add    %r12,%rsp         # Restore stack pointer
0x00007ffff7af58e2 <+146>:   mov    %rax,-0x20(%rbp)  # Store syscall return value in local variable
0x00007ffff7af58e6 <+150>:   mov    -0x20(%rbp),%rax
0x00007ffff7af58ea <+154>:   mov    -0x8(%rbp),%r12 
0x00007ffff7af58ee <+158>:   leave
0x00007ffff7af58ef <+159>:   ret
```
movaps` requires 16 byte aligned memory operands, which is not the case here. I'm not sure why gcc compiles to it. this also happens with `-O0`. Perhaps the inline asms modify stack alignment in a way the compiler is unaware of? But if it is unsure, why does it use instructions requiring alignment? 

The explicit setting of the NULL fields eliminates the `movaps` instructions, zeroing out with `movq`  instead. This has no  alignment requirements, thus it does not segfault.

 